### PR TITLE
Support capability tags as namespace labels, incl updating

### DIFF
--- a/feats/messaging/handlers/aws_context_account_created.go
+++ b/feats/messaging/handlers/aws_context_account_created.go
@@ -17,15 +17,31 @@ import (
 	"k8s.io/utils/env"
 )
 
+type CapabilityMetadata struct {
+	CostCentre          string `json:"dfds.cost.centre"`
+	Env                 string `json:"dfds.env"`
+	BusinessCapability  string `json:"dfds.other.businessCapability"`
+	DataClassification  string `json:"dfds.data.classification"`
+	ServiceCriticality  string `json:"dfds.service.criticality"`
+	ServiceAvailability string `json:"dfds.service.availability"`
+}
+
 type AWSContextAccountCreated struct {
-	AccountId        string `json:"accountId"`
-	CapabilityId     string `json:"capabilityId"`
-	CapabilityName   string `json:"capabilityName"`
-	CapabilityRootId string `json:"capabilityRootId"`
-	ContextId        string `json:"contextId"`
-	ContextName      string `json:"contextName"`
-	RoleArn          string `json:"roleArn"`
-	RoleEmail        string `json:"roleEmail"`
+	AccountId        string               `json:"accountId"`
+	CapabilityId     string               `json:"capabilityId"`
+	CapabilityName   string               `json:"capabilityName"`
+	CapabilityRootId string               `json:"capabilityRootId"`
+	ContextId        string               `json:"contextId"`
+	ContextName      string               `json:"contextName"`
+	RoleArn          string               `json:"roleArn"`
+	RoleEmail        string               `json:"roleEmail"`
+	Metadata         *CapabilityMetadata  `json:"metadata,omitempty"`
+}
+
+type CapabilityMetadataUpdated struct {
+	CapabilityId     string              `json:"capabilityId"`
+	CapabilityRootId string              `json:"capabilityRootId"`
+	Metadata         CapabilityMetadata  `json:"metadata"`
 }
 
 func AwsContextAccountCreatedHandler(ctx context.Context, event model.HandlerContext) error {
@@ -48,16 +64,23 @@ func AwsContextAccountCreatedHandler(ctx context.Context, event model.HandlerCon
 		if errors.IsNotFound(err) {
 			logger.Debug("Namespace missing, creating it")
 
+			labels := map[string]string{
+				"dfds.cloud/capability":              msg.Payload.CapabilityRootId,
+				"dfds.cloud/reconcile":               "true",
+				"dfds.cloud/context-id":              msg.Payload.ContextId,
+				"dfds.cloud/aws-account":             msg.Payload.AccountId,
+				"pod-security.kubernetes.io/enforce": "baseline",
+			}
+
+			// Add metadata labels if present
+			if msg.Payload.Metadata != nil {
+				addMetadataLabels(labels, *msg.Payload.Metadata)
+			}
+
 			_, err := client.CoreV1().Namespaces().Create(ctx, &v1Core.Namespace{
 				ObjectMeta: v1.ObjectMeta{
-					Name: msg.Payload.CapabilityRootId,
-					Labels: map[string]string{
-						"dfds.cloud/capability":              msg.Payload.CapabilityRootId,
-						"dfds.cloud/reconcile":               "true",
-						"dfds.cloud/context-id":              msg.Payload.ContextId,
-						"dfds.cloud/aws-account":             msg.Payload.AccountId,
-						"pod-security.kubernetes.io/enforce": "baseline",
-					},
+					Name:   msg.Payload.CapabilityRootId,
+					Labels: labels,
 				},
 			}, v1.CreateOptions{})
 			if err != nil {
@@ -96,6 +119,72 @@ func AwsContextAccountCreatedHandler(ctx context.Context, event model.HandlerCon
 	}
 
 	return nil
+}
+
+func CapabilityMetadataUpdatedHandler(ctx context.Context, event model.HandlerContext) error {
+	logging.Logger.Info("capability_metadata_updated received")
+
+	msg, err := messagingModel.SerialiseToEnvelopeWithPayload[CapabilityMetadataUpdated](event.Msg)
+	if err != nil {
+		return err
+	}
+
+	logger := logging.Logger.With(zap.String("handler", "capability_metadata_updated"), zap.String("capability_id", msg.Payload.CapabilityId))
+
+	client, err := getK8sClient()
+	if err != nil {
+		return err
+	}
+
+	// Get the existing namespace
+	ns, err := client.CoreV1().Namespaces().Get(ctx, msg.Payload.CapabilityRootId, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Warn("Namespace not found, skipping metadata update")
+			return nil
+		}
+		logger.Error("Failed to get namespace", zap.Error(err))
+		return err
+	}
+
+	// Initialize labels map if nil
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+
+	// Update labels with metadata
+	addMetadataLabels(ns.Labels, msg.Payload.Metadata)
+
+	// Update the namespace
+	_, err = client.CoreV1().Namespaces().Update(ctx, ns, v1.UpdateOptions{})
+	if err != nil {
+		logger.Error("Failed to update namespace labels", zap.Error(err))
+		return err
+	}
+
+	logger.Info("Successfully updated namespace labels")
+	return nil
+}
+
+func addMetadataLabels(labels map[string]string, metadata CapabilityMetadata) {
+	if metadata.CostCentre != "" {
+		labels["dfds.cost.centre"] = metadata.CostCentre
+	}
+	if metadata.Env != "" {
+		labels["dfds.env"] = metadata.Env
+	}
+	if metadata.BusinessCapability != "" {
+		labels["dfds.other.businessCapability"] = metadata.BusinessCapability
+	}
+	if metadata.DataClassification != "" {
+		labels["dfds.data.classification"] = metadata.DataClassification
+	}
+	if metadata.ServiceCriticality != "" {
+		labels["dfds.service.criticality"] = metadata.ServiceCriticality
+	}
+	if metadata.ServiceAvailability != "" {
+		labels["dfds.service.availability"] = metadata.ServiceAvailability
+	}
 }
 
 func getK8sClient() (*kubernetes.Clientset, error) {

--- a/feats/messaging/messaging.go
+++ b/feats/messaging/messaging.go
@@ -1,13 +1,14 @@
 package messaging
 
 import (
+	"sync"
+
 	"go.dfds.cloud/bootstrap"
 	"go.dfds.cloud/messaging"
 	"go.dfds.cloud/messaging/kafka/model"
 	"go.dfds.cloud/ssu-k8s/core/logging"
 	"go.dfds.cloud/ssu-k8s/feats/messaging/handlers"
 	"go.uber.org/zap"
-	"sync"
 )
 
 func Init(manager *bootstrap.Manager) (*messaging.Messaging, *sync.WaitGroup) {
@@ -30,6 +31,7 @@ func Init(manager *bootstrap.Manager) (*messaging.Messaging, *sync.WaitGroup) {
 func configure(msg *messaging.Messaging) {
 	auditConsumer := msg.NewConsumer("build.selfservice.events.capabilities", "cloudengineering.ssu-k8s")
 	auditConsumer.Register("aws_context_account_created", handlers.AwsContextAccountCreatedHandler)
+	auditConsumer.Register("capability_metadata_updated", handlers.CapabilityMetadataUpdatedHandler)
 
 	handlerContext := &model.HandlerContext{
 		Writer: msg.NewPublisher().Writer,


### PR DESCRIPTION
# Changes
- Support capability metadata as labels when creating namespace
- Support listening for metadata update events, for updating the namespace

# Requirements
- Event producers must include metadata
- Producer for capability update must be created